### PR TITLE
add deleteDateRange function

### DIFF
--- a/aanalytics2/aanalytics2.py
+++ b/aanalytics2/aanalytics2.py
@@ -1050,6 +1050,21 @@ class Analytics:
             headers=self.header
         )
         return dr
+    
+    def deleteDateRange(self, dateRangeID: str = None) -> object:
+        """
+        Method that deletes a specific date Range based on the id passed.
+        Arguments:
+            dateRangeID : REQUIRED : ID of Date Range  to be deleted
+        """
+        if dateRangeID is None:
+            print('No Date Range ID has been pushed')
+            return None
+        response = self.connector.deleteData(
+            self.endpoint_company + self._getDateRanges + '/' + dateRangeID,
+            headers=self.header
+        )
+        return response
 
     def getCalculatedFunctions(self, **kwargs) -> pd.DataFrame:
         """


### PR DESCRIPTION
This function is not officially listed in the API docs, but it works for me. It would be a useful addition, also to the GoogleSheets Component Manager where currently deletion is only possible for segments and Calc Metrics.