### PR TITLE
handling of "full" parameter in getScheduledJobs

### DIFF
--- a/aanalytics2/aanalytics2.py
+++ b/aanalytics2/aanalytics2.py
@@ -1401,7 +1401,7 @@ class Analytics:
                   "page": 0,
                   "limit": limit
                   }
-        if full is None:
+        if full is True:
             params["expansion"] = "ownerFullName,groups,tags,sharesFullName,modified,favorite,approved,scheduledItemName,scheduledUsersFullNames,deletedReason"
         path = "/scheduler/scheduler/scheduledjobs/"
         if verbose:


### PR DESCRIPTION
Sorry I didn't get to fully deep-diving into the way getScheduledJobs was implemented in the end (via https://github.com/pitchmuc/adobe-analytics-api-2.0/pull/65 ). 

Maybe I don't get it, but the docstring says `full` defaults to `True`. However, the code then checks for `full is None`. That is always False because True is not None. So the `params["expansion"]` row can never be reached. So there seems to be no way to set expansion parameters (there is no handling for any expansion parameter input)

I see 2 options:
a) remove the full Parameter entirely, and have the function simply always run with all expansion parameters (user can then filter out what he does not need)
b) provide a parameter e.g. `columns` that needs to be specified when `full` is `False` -> but imho this method is not that important so a) would be totally enough