### PR TITLE
Add shareComponent method

### DIFF
--- a/aanalytics2/aanalytics2.py
+++ b/aanalytics2/aanalytics2.py
@@ -2606,7 +2606,40 @@ class Analytics:
                 self.logger.debug(f'Full comparison, file : comparison_full_{element}_{int(time.time())}.csv')
         return df
         
+    def shareComponent(self, componentId: str = None, componentType: str = None, shareToId: int = None,
+                       shareToImsId: int = None, shareToType: str = None, shareToLogin: str = None,
+                       accessLevel: str = None, shareFromImsId: str = None) -> dict:
+        """
+        Shares a component with an individual or a group (product profile ID) a dictionary on the calculated metrics requested.
+        Arguments:
+            calculatedMetricId : REQUIRED : The calculated metric ID to be retrieved.
+            full : OPTIONAL : additional segment metadata fields to include on response (list)
+                additional infos: reportSuiteName,definition, ownerFullName, modified, tags, compatibility
+                @param accessLevel: for project sharing: "view", "edit", "duplicate"
+                @param componentId: REQUIRED: ID of the component to share
+                @param componentType: REQUIRED: Type of the component to share ("calculatedMetric", "segment", "project", "dateRange")
+                @param shareToId: ID of the user or the group to share to
+                @param shareToImsId: IMS ID of the user to share to (alternative to ID)
+                @param shareToLogin: Login of the user to share to (alternative to ID)                
+                @param shareToType: "group" => share to a group (product profile), "user" => share to a user, "all" => share to all users (in this case, no shareToId or shareToImsId is needed)
+                @return: response from the API
+        """
 
+        if self.loggingEnabled:
+            self.logger.debug(f"Starting to share component ID {componentId} with parameters: {locals()}")
+        path = f"/componentmetadata/shares/"
+        data = {
+            "accessLevel": accessLevel,
+            "componentId": componentId,
+            "componentType": componentType,
+            "shareToId": shareToId,
+            "shareToImsId": shareToImsId,
+            "shareToLogin": shareToLogin,
+            "shareToType": shareToType
+        }
+        res = self.connector.postData(self.endpoint_company + path, data=data)
+        return res
+        
     def _dataDescriptor(self, json_request: dict):
         """
         read the request and returns an object with information about the request.

--- a/aanalytics2/aanalytics2.py
+++ b/aanalytics2/aanalytics2.py
@@ -2611,18 +2611,14 @@ class Analytics:
                        accessLevel: str = None, shareFromImsId: str = None) -> dict:
         """
         Shares a component with an individual or a group (product profile ID) a dictionary on the calculated metrics requested.
+        Returns the JSON response from the API. 
         Arguments:
-            calculatedMetricId : REQUIRED : The calculated metric ID to be retrieved.
-            full : OPTIONAL : additional segment metadata fields to include on response (list)
-                additional infos: reportSuiteName,definition, ownerFullName, modified, tags, compatibility
-                @param accessLevel: for project sharing: "view", "edit", "duplicate"
-                @param componentId: REQUIRED: ID of the component to share
-                @param componentType: REQUIRED: Type of the component to share ("calculatedMetric", "segment", "project", "dateRange")
-                @param shareToId: ID of the user or the group to share to
-                @param shareToImsId: IMS ID of the user to share to (alternative to ID)
-                @param shareToLogin: Login of the user to share to (alternative to ID)                
-                @param shareToType: "group" => share to a group (product profile), "user" => share to a user, "all" => share to all users (in this case, no shareToId or shareToImsId is needed)
-                @return: response from the API
+            componentId : REQUIRED : The component ID to share.
+            componentType : REQUIRED : The component Type ("calculatedMetric", "segment", "project", "dateRange")
+            shareToId: ID of the user or the group to share to
+            shareToImsId: IMS ID of the user to share to (alternative to ID)
+            shareToLogin: Login of the user to share to (alternative to ID)                
+            shareToType: "group" => share to a group (product profile), "user" => share to a user, "all" => share to all users (in this case, no shareToId or shareToImsId is needed)
         """
 
         if self.loggingEnabled:


### PR DESCRIPTION
Honestly, the documentation on https://adobedocs.github.io/analytics-2.0-apis/ is not great enough so I may misinterpret some of those parameters.
Also, there seems to be no way to get the group IDs (product profiles) you could theoretically share to.
Still it definitely works for sharing to individuals and all users.