### PR TITLE
Handle error in getDimensions when Report Suite does not have any cla…

### DIFF
--- a/aanalytics2/aanalytics2.py
+++ b/aanalytics2/aanalytics2.py
@@ -573,6 +573,9 @@ class Analytics:
         df_dims = pd.DataFrame(dims)
         columns = ['id', 'name', 'category', 'type',
                    'parent', 'pathable']
+        for col in columns:
+            if col not in df_dims.columns:
+                df_dims[col] = ""
         if description:
             columns.append('description')
         if kwargs.get('full', False):


### PR DESCRIPTION
…ssifications

In case a RS has no classifications, the "parent" column does not exist and getDimensions throws an error.  To make all "getDimensions" calls return an identical set of standard columns, we create empty columns in this case. We thus also avoid an error. @pitchmuc The even more "standard" way would be to have a column full of np.NaN, but I did not want to add a numpy dependency just for this case. If you prefer another solution (e.g. not returning a column that does not exist at all, but also not throwing an Exception), I am fine with that, too. It is just a suggestion.