### PR TITLE
Improve failed login error handling

### DIFF
--- a/aanalytics2/token_provider.py
+++ b/aanalytics2/token_provider.py
@@ -43,6 +43,7 @@ def get_token_and_expiry_for_config(config: dict, verbose: bool = False, save: b
     except KeyError:
         print('Issue retrieving token')
         print(json_response)
+        raise Exception(str(json_response))
     expiry = json_response['expires_in']
     if save:
         with open('token.txt', 'w') as f:


### PR DESCRIPTION
Right now, the handling of failed logins is suboptimal: The script prints the error, but continues with evaluating the json_response, which then fails because there is obviously no `expires_in` property in this case.  The function should return the erroneous json_response or raise an Exception so it can be propagated to the calling function (and eg shown to the user of the application).  Right now the users get a very unhelpful error message, it is only:"'expires_in'". With a proper Exception, the error for eg false jwt credentials is: "{'error_description': 'Could not match JWT signature to any of the bindings', 'error': 'invalid_token'}" => much more helpful