### PR TITLE
Fix report2 outputs

### DIFF
--- a/aanalytics2/workspace.py
+++ b/aanalytics2/workspace.py
@@ -177,7 +177,7 @@ class Workspace:
         """
         if filename is None:
             filename = f"cjapy_{int(time.time())}.json"
-        self.df_init.to_json(filename, orient=orient)
+        self.dataframe.to_json(filename, orient=orient)
 
     def breakdown(
         self,

--- a/aanalytics2/workspace.py
+++ b/aanalytics2/workspace.py
@@ -166,7 +166,7 @@ class Workspace:
         """
         if filename is None:
             filename = f"cjapy_{int(time.time())}.csv"
-        self.df_init.to_csv(filename, delimiter=delimiter, index=index)
+        self.dataframe.to_csv(filename, sep=delimiter, index=index)
 
     def to_json(self, filename: str = None, orient: str = "index") -> IO:
         """


### PR DESCRIPTION
These changes fix attempting to use `getReport2()` with the `save` parameter.
On 0.4.0.post3, doing so results in the following error:
```
Traceback (most recent call last):
  File "report-to-csv.py", line 42, in <module>
    print(analytics.getReport2(args.filename, save=True))
  File ".venv/lib/python3.10/site-packages/aanalytics2/aanalytics2.py", line 3204, in getReport2
    data.to_csv()
  File ".venv/lib/python3.10/site-packages/aanalytics2/workspace.py", line 169, in to_csv
    self.df_init.to_csv(filename, delimiter=delimiter, index=index)
AttributeError: 'Workspace' object has no attribute 'df_init'
```

This appears to be because the `Workspace.to_csv()` and `Workspace.to_json()` methods incorrectly reference a `df_init` attribute, when the dataframe is saved as `self.dataframe`.

Whilst fixing this issue, I also noticed that `DataFrame.to_csv()` is called with non-existant keyword argument `delimiter`, which I have updated to `sep`.