### PR TITLE
getMetrics and getDimensions are failing due to changed "support" column values in AA API

### DIFF
--- a/aanalytics2/aanalytics2.py
+++ b/aanalytics2/aanalytics2.py
@@ -585,8 +585,9 @@ class Analytics:
         if description:
             columns.append('description')
         if kwargs.get('full', False):
+            support_columns = list(set([item for sublist in df_dims.support for item in sublist]))
             new_cols = pd.DataFrame(df_dims.support.values.tolist(),
-                                    columns=['support_oberon', 'support_dw'])  # extract list in column
+                                    columns=support_columns)  # extract list in column
             new_df = df_dims.merge(new_cols, right_index=True, left_index=True)
             new_df.drop(['reportable', 'support'], axis=1, inplace=True)
             df_dims = new_df
@@ -625,8 +626,8 @@ class Analytics:
         if description:
             columns.append('description')
         if kwargs.get('full', False):
-            new_cols = pd.DataFrame(df_metrics.support.values.tolist(), columns=[
-                'support_oberon', 'support_dw'])
+            support_columns = list(set([item for sublist in df_metrics.support for item in sublist]))
+            new_cols = pd.DataFrame(df_metrics.support.values.tolist(), columns=support_columns)
             new_df = df_metrics.merge(
                 new_cols, right_index=True, left_index=True)
             new_df.drop('support', axis=1, inplace=True)


### PR DESCRIPTION
getMetrics and getDimensions are failing if run with the "full" command. This also makes compareReportSuites fail and potentially other parts of the wrapper, so ideally this PR can be merged soon. I have updated the logic to make it less dependent on hard-coded values in the "support" columns. @pitchmuc 