### PR TITLE
Change checkFiles for ingestion so the uploaded file does not need to be located in the same folder as the script

### DIFF
--- a/aanalytics2/ingestion.py
+++ b/aanalytics2/ingestion.py
@@ -208,7 +208,8 @@ class Bulkapi:
             new_folder.mkdir(exist_ok=True)
             with open(file, "r",encoding=encoding) as f:
                 content = f.read()
-                new_path = new_folder / f"{file}.gz"
+                file_name = Path(file).name
+                new_path = new_folder / f"{file_name}.gz"
                 with gzip.open(Path(new_path), 'wb') as f:
                     f.write(content.encode('utf-8'))
                 # save the filename to delete


### PR DESCRIPTION
The files I am uploading are not in the same folder as the script accessing the ingestion API (e.g. "files/upload_file.csv")

Previously, the script tried to create the temp file with the following path: "tmp/files/upload_file.csv.gz", which lead to an error due to "/tmp/files" not existing.  This meant the upload only worked if the files were located in the same folder as the script

I changed the implementation, so the temp path is now only based on the file name: "tmp/upload_file.csv.gz". 

