### PR TITLE
Allow getProjects with custom expansion parameters (also to avoid issues with externalReferences column)

### DIFF
--- a/aanalytics2/aanalytics2.py
+++ b/aanalytics2/aanalytics2.py
@@ -1739,16 +1739,17 @@ class Analytics:
         res = self.connector.deleteData(self.endpoint_company + path)
         return res
 
-    def getProjects(self, includeType: str = 'all', full: bool = False, limit: int = None, includeShared: bool = False,
-                    includeTemplate: bool = False, format: str = 'df', cache: bool = False,
+    def getProjects(self, includeType: str = 'all', full: bool = False, expansion: str = None, limit: int = None,
+                    includeShared: bool = False, includeTemplate: bool = False, format: str = 'df', cache: bool = False,
                     save: bool = False) -> JsonListOrDataFrameType:
         """
         Returns the list of projects through either a dataframe or a list.
         Arguments:
-            includeType : OPTIONAL : type of projects to be retrieved.(str) Possible values:
+            includeType : OPTIONAL : type of projects to be retrieved.(str) Possible values: 
                 - all : Default value (all projects possibles)
                 - shared : shared projects
             full : OPTIONAL : if set to True, returns all information about projects.
+            expansion : OPTIONAL : if set, limits the request to the listed expansion parameters
             limit : OPTIONAL : Limit the number of result returned.
             includeShared : OPTIONAL : If full is set to False, you can retrieve only information about sharing.
             includeTemplate: OPTIONAL : If full is set to False, you can add information about template here.
@@ -1769,6 +1770,9 @@ class Analytics:
                 params["expansion"] += ',shares,sharesFullName'
             if includeTemplate:
                 params["expansion"] += ',companyTemplate'
+        if expansion is not None:
+            # override the default expansion values in case an explicit expansion parameter is present
+            params["expansion"] = expansion
         if limit is not None:
             params['limit'] = limit
         if self.loggingEnabled:


### PR DESCRIPTION
Right now, the "expansion" parameter for the `getProjects` method is always either the `full` list of `'reportSuiteName,ownerFullName,tags,shares,sharesFullName,modified,favorite,approved,companyTemplate,externalReferences,accessLevel'` or the smaller subset of: 

```            
            params["expansion"] = "ownerFullName,modified"
            if includeShared:
                params["expansion"] += ',shares,sharesFullName'
            if includeTemplate:
                params["expansion"] += ',companyTemplate'
```

In some cases where clients have 10s of thousands of projects, you can speed up the query by limiting the expansion parameters.

Also, the "externalReferences" expansion parameter causes the getProjects request to fail for a client of mine ("Connection broken"). Since `externalReferences` does not contain anything of value for us, we could live without it, but for that we need a way to query getProjects with a custom expansion parameter list.

This simple change will allow that. So thanks for looking at this, @pitchmuc