### PR TITLE
Avoid keyError: "retry" in case request fails

### DIFF
--- a/aanalytics2/connector.py
+++ b/aanalytics2/connector.py
@@ -134,8 +134,9 @@ class AdobeRequest:
                     print('Retry parameter activated')
                     print(f'{internRetry} retry left')
                 if 'error' in res_json.keys():
-                    time.sleep(30)
-                    res_json = self.getData(endpoint, params=params, data=data, headers=headers, retry=internRetry-1, **kwargs)
+                    time.sleep(self.restTime)
+                    kwargs["retry"] = internRetry - 1
+                    res_json = self.getData(endpoint, params=params, data=data, headers=headers, **kwargs)
                     return res_json
         return res_json
 


### PR DESCRIPTION
If a request fails completely (eg "Connection broken" due to giant segments), the connector.py tries again. However, the second time this happens, there is a conflict between the retry parameter in kwargs and the separate retry parameter which leads to a "keyError: 'retry'" error. This can be avoided via the changes here. I also set time.sleep to the  connector.restTime so this is consistent with the rest of the retries.